### PR TITLE
Add Procfile for Ruby sample app

### DIFF
--- a/apps/ruby-bundler/Procfile
+++ b/apps/ruby-bundler/Procfile
@@ -1,0 +1,1 @@
+web: ruby app.rb


### PR DESCRIPTION
Addresses https://github.com/buildpacks/samples/issues/46.

Adds a standard `Procfile` to the ruby sample app to ensure it can be run correctly by the Heroku builder.