### PR TITLE
Make buildpack IDs compatible with the registry convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ build-stack-bionic:
 
 build-builders: build-builder-alpine build-builder-bionic
 
-build-builder-alpine:
+build-builder-alpine: build-packages
 	@echo "> Building 'alpine' builder..."
 	$(PACK_CMD) create-builder cnbs/sample-builder:alpine --builder-config builders/alpine/builder.toml $(PACK_FLAGS)
 
-build-builder-bionic:
+build-builder-bionic: build-packages
 	@echo "> Building 'bionic' builder..."
 	$(PACK_CMD) create-builder cnbs/sample-builder:bionic --builder-config builders/bionic/builder.toml $(PACK_FLAGS)
 

--- a/apps/bash-script/bash-script-buildpack/buildpack.toml
+++ b/apps/bash-script/bash-script-buildpack/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 
 # Buildpack ID and metadata
 [buildpack]
-id = "io.buildpacks.samples.bash-script"
+id = "buildpacks-io-samples/bash-script"
 version = "0.0.1"
 name = "Bash Script Buildpack"
 

--- a/builders/alpine/builder.toml
+++ b/builders/alpine/builder.toml
@@ -1,11 +1,11 @@
 # Buildpacks to include in builder
 [[buildpacks]]
-id = "io.buildpacks.samples.java-maven"
+id = "buildpacks-io-samples/java-maven"
 version = "0.0.1"
 uri = "../../buildpacks/java-maven"
 
 [[buildpacks]]
-id = "io.buildpacks.samples.kotlin-gradle"
+id = "buildpacks-io-samples/kotlin-gradle"
 version = "0.0.1"
 uri = "../../buildpacks/kotlin-gradle"
 
@@ -15,17 +15,17 @@ image = "cnbs/sample-package:hello-universe"
 # Order used for detection
 [[order]]
 [[order.group]]
-id = "io.buildpacks.samples.java-maven"
+id = "buildpacks-io-samples/java-maven"
 version = "0.0.1"
 
 [[order]]
 [[order.group]]
-id = "io.buildpacks.samples.kotlin-gradle"
+id = "buildpacks-io-samples/kotlin-gradle"
 version = "0.0.1"
 
 [[order]]
 [[order.group]]
-id = "io.buildpacks.samples.hello-universe"
+id = "buildpacks-io-samples/hello-universe"
 version = "0.0.1"
 
 # Stack that will be used by the builder

--- a/builders/bionic/builder.toml
+++ b/builders/bionic/builder.toml
@@ -1,16 +1,16 @@
 # Buildpacks to include in builder
 [[buildpacks]]
-id = "io.buildpacks.samples.java-maven"
+id = "buildpacks-io-samples/java-maven"
 version = "0.0.1"
 uri = "../../buildpacks/java-maven"
 
 [[buildpacks]]
-id = "io.buildpacks.samples.kotlin-gradle"
+id = "buildpacks-io-samples/kotlin-gradle"
 version = "0.0.1"
 uri = "../../buildpacks/kotlin-gradle"
 
 [[buildpacks]]
-id = "io.buildpacks.samples.ruby-bundler"
+id = "buildpacks-io-samples/ruby-bundler"
 version = "0.0.1"
 uri = "../../buildpacks/ruby-bundler"
 
@@ -20,22 +20,22 @@ image = "cnbs/sample-package:hello-universe"
 # Order used for detection
 [[order]]
 [[order.group]]
-id = "io.buildpacks.samples.java-maven"
+id = "buildpacks-io-samples/java-maven"
 version = "0.0.1"
 
 [[order]]
 [[order.group]]
-id = "io.buildpacks.samples.kotlin-gradle"
+id = "buildpacks-io-samples/kotlin-gradle"
 version = "0.0.1"
 
 [[order]]
 [[order.group]]
-id = "io.buildpacks.samples.ruby-bundler"
+id = "buildpacks-io-samples/ruby-bundler"
 version = "0.0.1"
 
 [[order]]
 [[order.group]]
-id = "io.buildpacks.samples.hello-universe"
+id = "buildpacks-io-samples/hello-universe"
 version = "0.0.1"
 
 # Stack that will be used by the builder

--- a/buildpacks/hello-moon/buildpack.toml
+++ b/buildpacks/hello-moon/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 
 # Buildpack ID and metadata
 [buildpack]
-id = "io.buildpacks.samples.hello-moon"
+id = "buildpacks-io-samples/hello-moon"
 version = "0.0.1"
 name = "Hello Moon Buildpack"
 homepage = "https://github.com/buildpacks/samples/tree/master/buildpacks/hello-moon"

--- a/buildpacks/hello-processes/buildpack.toml
+++ b/buildpacks/hello-processes/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 
 # Buildpack ID and metadata
 [buildpack]
-id = "io.buildpacks.samples.hello-processes"
+id = "buildpacks-io-samples/hello-processes"
 version = "0.0.1"
 name = "Hello Processes Buildpack"
 homepage = "https://github.com/buildpacks/samples/tree/master/buildpacks/hello-process"

--- a/buildpacks/hello-universe/buildpack.toml
+++ b/buildpacks/hello-universe/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 
 # Buildpack ID and metadata
 [buildpack]
-id = "io.buildpacks.samples.hello-universe"
+id = "buildpacks-io-samples/hello-universe"
 version = "0.0.1"
 name = "Hello Universe Buildpack"
 homepage = "https://github.com/buildpacks/samples/tree/master/buildpacks/hello-universe"
@@ -11,9 +11,9 @@ homepage = "https://github.com/buildpacks/samples/tree/master/buildpacks/hello-u
 # Order used for detection
 [[order]]
 [[order.group]]
-id = "io.buildpacks.samples.hello-world"
+id = "buildpacks-io-samples/hello-world"
 version = "0.0.1"
 
 [[order.group]]
-id = "io.buildpacks.samples.hello-moon"
+id = "buildpacks-io-samples/hello-moon"
 version = "0.0.1"

--- a/buildpacks/hello-world/buildpack.toml
+++ b/buildpacks/hello-world/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 
 # Buildpack ID and metadata
 [buildpack]
-id = "io.buildpacks.samples.hello-world"
+id = "buildpacks-io-samples/hello-world"
 version = "0.0.1"
 name = "Hello World Buildpack"
 homepage = "https://github.com/buildpacks/samples/tree/master/buildpacks/hello-world"

--- a/buildpacks/java-maven/buildpack.toml
+++ b/buildpacks/java-maven/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 
 # Buildpack ID and metadata
 [buildpack]
-id = "io.buildpacks.samples.java-maven"
+id = "buildpacks-io-samples/java-maven"
 version = "0.0.1"
 name = "Sample Java Maven Buildpack"
 homepage = "https://github.com/buildpacks/samples/tree/master/buildpacks/java-maven"

--- a/buildpacks/kotlin-gradle/buildpack.toml
+++ b/buildpacks/kotlin-gradle/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 
 # Buildpack ID and metadata
 [buildpack]
-id = "io.buildpacks.samples.kotlin-gradle"
+id = "buildpacks-io-samples/kotlin-gradle"
 version = "0.0.1"
 name = "Sample Kotlin Gradle Buildpack"
 homepage = "https://github.com/buildpacks/samples/tree/master/buildpacks/kotlin-gradle"

--- a/buildpacks/ruby-bundler/buildpack.toml
+++ b/buildpacks/ruby-bundler/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 
 # Buildpack ID and metadata
 [buildpack]
-id = "io.buildpacks.samples.ruby-bundler"
+id = "buildpacks-io-samples/ruby-bundler"
 version = "0.0.1"
 name = "Sample Ruby Buildpack"
 homepage = "https://github.com/buildpacks/samples/tree/master/buildpacks/ruby-bundler"


### PR DESCRIPTION
Signed-off-by: Javier Romero <rjavier@vmware.com>