### PR TITLE
Buildpacks support io.buildpacks.stacks.bionic

### DIFF
--- a/apps/bash-script/bash-script-buildpack/buildpack.toml
+++ b/apps/bash-script/bash-script-buildpack/buildpack.toml
@@ -13,3 +13,6 @@ id = "io.buildpacks.samples.stacks.bionic"
 
 [[stacks]]
 id = "io.buildpacks.samples.stacks.alpine"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"

--- a/buildpacks/hello-moon/buildpack.toml
+++ b/buildpacks/hello-moon/buildpack.toml
@@ -14,3 +14,6 @@ id = "io.buildpacks.samples.stacks.bionic"
 
 [[stacks]]
 id = "io.buildpacks.samples.stacks.alpine"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"

--- a/buildpacks/hello-processes/buildpack.toml
+++ b/buildpacks/hello-processes/buildpack.toml
@@ -14,3 +14,6 @@ id = "io.buildpacks.samples.stacks.bionic"
 
 [[stacks]]
 id = "io.buildpacks.samples.stacks.alpine"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"

--- a/buildpacks/hello-world/buildpack.toml
+++ b/buildpacks/hello-world/buildpack.toml
@@ -14,3 +14,6 @@ id = "io.buildpacks.samples.stacks.bionic"
 
 [[stacks]]
 id = "io.buildpacks.samples.stacks.alpine"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"

--- a/buildpacks/java-maven/buildpack.toml
+++ b/buildpacks/java-maven/buildpack.toml
@@ -15,3 +15,6 @@ id = "io.buildpacks.samples.stacks.bionic"
 
 [[stacks]]
 id = "io.buildpacks.samples.stacks.alpine"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"

--- a/buildpacks/kotlin-gradle/buildpack.toml
+++ b/buildpacks/kotlin-gradle/buildpack.toml
@@ -14,3 +14,6 @@ id = "io.buildpacks.samples.stacks.bionic"
 
 [[stacks]]
 id = "io.buildpacks.samples.stacks.alpine"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"

--- a/buildpacks/ruby-bundler/buildpack.toml
+++ b/buildpacks/ruby-bundler/buildpack.toml
@@ -11,3 +11,6 @@ homepage = "https://github.com/buildpacks/samples/tree/main/buildpacks/ruby-bund
 # Stacks that the buildpack will work with
 [[stacks]]
 id = "io.buildpacks.samples.stacks.bionic"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
It would be very convenient if the sample buildpacks could be used on `io.buildpacks.stacks.bionic`.

Given that the project has defined the `io.buildpacks.stacks.bionic` ID and mixin rules it seems reasonable to me the sample buildpacks should support it, even if we purposefully use a different stack in the builder image (for demonstration purposes).