### PR TITLE
Add build:set=shell-utils mixin to bionic stack where required

### DIFF
--- a/buildpacks/java-maven/buildpack.toml
+++ b/buildpacks/java-maven/buildpack.toml
@@ -18,3 +18,4 @@ id = "io.buildpacks.samples.stacks.alpine"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
+mixins = ["build:set=shell-utils"]

--- a/buildpacks/kotlin-gradle/buildpack.toml
+++ b/buildpacks/kotlin-gradle/buildpack.toml
@@ -17,3 +17,4 @@ id = "io.buildpacks.samples.stacks.alpine"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
+mixins = ["build:set=shell-utils"]

--- a/buildpacks/ruby-bundler/buildpack.toml
+++ b/buildpacks/ruby-bundler/buildpack.toml
@@ -14,3 +14,4 @@ id = "io.buildpacks.samples.stacks.bionic"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
+mixins = ["build:set=shell-utils"]


### PR DESCRIPTION
This mixin provides jq and yq shell utilities as defined in https://github.com/buildpacks/rfcs/blob/main/text/0031-bionic-mixins.md\#proposal

Resolves #79 