### PR TITLE
Update hello-universe to use a public image

### DIFF
--- a/packages/hello-universe/package.toml
+++ b/packages/hello-universe/package.toml
@@ -5,4 +5,6 @@ uri = "../../buildpacks/hello-universe/"
 uri = "../../buildpacks/hello-moon"
 
 [[dependencies]]
-image = "cnbs/sample-package:hello-world"
+uri = "../../buildpacks/hello-world"
+# Alternatively, to use an image while packaging, you can use:
+# image = "cnbs/sample-package:hello-world"

--- a/packages/hello-universe/package.toml
+++ b/packages/hello-universe/package.toml
@@ -5,4 +5,4 @@ uri = "../../buildpacks/hello-universe/"
 uri = "../../buildpacks/hello-moon"
 
 [[dependencies]]
-uri = "../../buildpacks/hello-world"
+image = "cnbs/sample-package:hello-world"


### PR DESCRIPTION
* This demonstrates that packages can also consume images

Signed-off-by: David Freilich <dfreilich@vmware.com>

As part of https://github.com/buildpacks/pack/pull/773, I was trying to demonstrate packaging with pulling images, and I realized that none of our samples repo have. This PR rectifies that. 