### PR TITLE
Replace builder-config/package-config with config flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACK_FLAGS?=--no-pull
+PACK_FLAGS?=--pull-policy=never
 PACK_BUILD_FLAGS?=--trust-builder
 PACK_CMD?=pack
 

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ build-builders: build-builder-alpine build-builder-bionic
 
 build-builder-alpine: build-packages
 	@echo "> Building 'alpine' builder..."
-	$(PACK_CMD) create-builder cnbs/sample-builder:alpine --builder-config builders/alpine/builder.toml $(PACK_FLAGS)
+	$(PACK_CMD) create-builder cnbs/sample-builder:alpine --config builders/alpine/builder.toml $(PACK_FLAGS)
 
 build-builder-bionic: build-packages
 	@echo "> Building 'bionic' builder..."
-	$(PACK_CMD) create-builder cnbs/sample-builder:bionic --builder-config builders/bionic/builder.toml $(PACK_FLAGS)
+	$(PACK_CMD) create-builder cnbs/sample-builder:bionic --config builders/bionic/builder.toml $(PACK_FLAGS)
 
 build-buildpacks: build-buildpacks-alpine build-buildpacks-bionic
 
@@ -71,10 +71,10 @@ build-buildpacks-bionic:
 
 build-packages:
 	@echo "> Creating 'hello-world' buildpack package"
-	$(PACK_CMD) package-buildpack cnbs/sample-package:hello-world --package-config packages/hello-world/package.toml $(PACK_FLAGS)
+	$(PACK_CMD) package-buildpack cnbs/sample-package:hello-world --config packages/hello-world/package.toml $(PACK_FLAGS)
 
 	@echo "> Creating 'hello-universe' buildpack package"
-	$(PACK_CMD) package-buildpack cnbs/sample-package:hello-universe --package-config packages/hello-universe/package.toml $(PACK_FLAGS)
+	$(PACK_CMD) package-buildpack cnbs/sample-package:hello-universe --config packages/hello-universe/package.toml $(PACK_FLAGS)
 
 deploy-linux: deploy-linux-stacks deploy-packages deploy-builders
 

--- a/builders/alpine/README.md
+++ b/builders/alpine/README.md
@@ -5,7 +5,7 @@
 #### Creating the builder
 
 ```bash
-pack create-builder cnbs/sample-builder:alpine --builder-config builder.toml
+pack create-builder cnbs/sample-builder:alpine --config builder.toml
 ```
 
 #### Build app with builder

--- a/builders/bionic/README.md
+++ b/builders/bionic/README.md
@@ -8,7 +8,7 @@
 #### Creating the builder
 
 ```bash
-pack create-builder cnbs/sample-builder:bionic --builder-config builder.toml
+pack create-builder cnbs/sample-builder:bionic --config builder.toml
 ```
 
 #### Build app with builder

--- a/packages/hello-universe/README.md
+++ b/packages/hello-universe/README.md
@@ -5,5 +5,5 @@ A no-op buildpack whose intent is to show how meta-buildpacks can be packaged.
 ### Usage
 
 ```bash
-pack create-package cnbs/sample-package:hello-universe --package-config package.toml
+pack create-package cnbs/sample-package:hello-universe --config package.toml
 ```


### PR DESCRIPTION
* Replace `--builder-config` / `--package-config` with `--config` flag.
* Also replaces `--no-pull` with `--pull-policy=never` flag.

NOTE: This is necessary based on the latest removal of deprecated flags in [pack 0.13.0](https://github.com/buildpacks/pack/releases/tag/v0.13.0).