### PR TITLE
Fixes missing make target for windows packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,11 @@ deploy-windows-stacks:
 	docker push cnbs/sample-stack-run:dotnet-framework-1809
 	docker push cnbs/sample-stack-build:dotnet-framework-1809
 
+deploy-windows-packages:
+	@echo "> Deploying windows packages..."
+	docker push cnbs/sample-package:hello-world-windows
+	docker push cnbs/sample-package:hello-universe-windows
+
 deploy-windows-builders:
 	@echo "> Deploying 'nanoserver-1809' builder..."
 	docker push cnbs/sample-builder:nanoserver-1809


### PR DESCRIPTION
Target was missing from initial PRs

Signed-off-by: Micah Young <ymicah@vmware.com>