### PR TITLE
Update commands to match pack 0.16.0

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -71,7 +71,8 @@ jobs:
           curl -s -L -o pack.zip ${{ steps.pack-download-url.outputs.result }}
           tar -xvf pack.zip
           mkdir ~\.pack
-          pack.exe config experimental true
+      - name: Set Experimental
+        run: make set-experimental
       - name: Build
         run: make build-windows
       - uses: azure/docker-login@v1

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -71,7 +71,7 @@ jobs:
           curl -s -L -o pack.zip ${{ steps.pack-download-url.outputs.result }}
           tar -xvf pack.zip
           mkdir ~\.pack
-          echo "experimental = true" | Out-File -Encoding ASCII ~\.pack\config.toml
+          pack.exe config experimental true
       - name: Build
         run: make build-windows
       - uses: azure/docker-login@v1

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,9 @@ clean-linux:
 	@echo "> Removing '.tmp'"
 	rm -rf .tmp
 
+set-experimental:
+	@echo "> Setting experimental"
+	$(PACK_CMD) config experimental true
 ####################
 ## Windows
 ####################

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ build-linux-builders: build-builder-alpine build-builder-bionic
 
 build-builder-alpine: build-linux-packages build-sample-root
 	@echo "> Building 'alpine' builder..."
-	$(PACK_CMD) create-builder cnbs/sample-builder:alpine --config $(SAMPLES_ROOT)/builders/alpine/builder.toml $(PACK_FLAGS)
+	$(PACK_CMD) builder create cnbs/sample-builder:alpine --config $(SAMPLES_ROOT)/builders/alpine/builder.toml $(PACK_FLAGS)
 
 build-builder-bionic: build-linux-packages build-sample-root
 	@echo "> Building 'bionic' builder..."
-	$(PACK_CMD) create-builder cnbs/sample-builder:bionic --config $(SAMPLES_ROOT)/builders/bionic/builder.toml $(PACK_FLAGS)
+	$(PACK_CMD) builder create cnbs/sample-builder:bionic --config $(SAMPLES_ROOT)/builders/bionic/builder.toml $(PACK_FLAGS)
 
 build-linux-buildpacks: build-buildpacks-alpine build-buildpacks-bionic
 
@@ -73,10 +73,10 @@ build-buildpacks-bionic: build-sample-root
 
 build-linux-packages: build-sample-root
 	@echo "> Creating 'hello-world' buildpack package"
-	$(PACK_CMD) package-buildpack cnbs/sample-package:hello-world --config $(SAMPLES_ROOT)/packages/hello-world/package.toml $(PACK_FLAGS)
+	$(PACK_CMD) buildpack package cnbs/sample-package:hello-world --config $(SAMPLES_ROOT)/packages/hello-world/package.toml $(PACK_FLAGS)
 
 	@echo "> Creating 'hello-universe' buildpack package"
-	$(PACK_CMD) package-buildpack cnbs/sample-package:hello-universe --config $(SAMPLES_ROOT)/packages/hello-universe/package.toml $(PACK_FLAGS)
+	$(PACK_CMD) buildpack package cnbs/sample-package:hello-universe --config $(SAMPLES_ROOT)/packages/hello-universe/package.toml $(PACK_FLAGS)
 
 deploy-linux: deploy-linux-stacks deploy-linux-packages deploy-linux-builders
 
@@ -162,11 +162,11 @@ build-windows-builders: build-builder-nanoserver-1809 build-builder-dotnet-frame
 
 build-builder-nanoserver-1809: build-sample-root build-windows-packages
 	@echo "> Building 'nanoserver-1809' builder..."
-	$(PACK_CMD) create-builder cnbs/sample-builder:nanoserver-1809 --config $(SAMPLES_ROOT)/builders/nanoserver-1809/builder.toml $(PACK_FLAGS)
+	$(PACK_CMD) builder create cnbs/sample-builder:nanoserver-1809 --config $(SAMPLES_ROOT)/builders/nanoserver-1809/builder.toml $(PACK_FLAGS)
 
 build-builder-dotnet-framework-1809: build-sample-root build-windows-packages
 	@echo "> Building 'dotnet-framework-1809' builder..."
-	$(PACK_CMD) create-builder cnbs/sample-builder:dotnet-framework-1809 --config $(SAMPLES_ROOT)/builders/dotnet-framework-1809/builder.toml $(PACK_FLAGS)
+	$(PACK_CMD) builder create cnbs/sample-builder:dotnet-framework-1809 --config $(SAMPLES_ROOT)/builders/dotnet-framework-1809/builder.toml $(PACK_FLAGS)
 
 build-windows-buildpacks: build-buildpacks-nanoserver-1809 build-buildpacks-dotnet-framework-1809
 
@@ -183,10 +183,10 @@ build-buildpacks-dotnet-framework-1809: build-sample-root
 
 build-windows-packages: build-sample-root
 	@echo "> Creating 'hello-world-windows' buildpack package"
-	$(PACK_CMD) package-buildpack cnbs/sample-package:hello-world-windows --config $(SAMPLES_ROOT)/packages/hello-world-windows/package.toml $(PACK_FLAGS)
+	$(PACK_CMD) buildpack package cnbs/sample-package:hello-world-windows --config $(SAMPLES_ROOT)/packages/hello-world-windows/package.toml $(PACK_FLAGS)
 
 	@echo "> Creating 'hello-universe-windows' buildpack package"
-	$(PACK_CMD) package-buildpack cnbs/sample-package:hello-universe-windows --config $(SAMPLES_ROOT)/packages/hello-universe-windows/package.toml $(PACK_FLAGS)
+	$(PACK_CMD) buildpack package cnbs/sample-package:hello-universe-windows --config $(SAMPLES_ROOT)/packages/hello-universe-windows/package.toml $(PACK_FLAGS)
 
 build-windows-apps: build-sample-root
 	@echo "> Creating 'batch-script' app using 'nanoserver-1809' builder..."

--- a/builders/README.md
+++ b/builders/README.md
@@ -8,7 +8,7 @@ A sample of builders that use the [stacks](../stacks/) in this repo.
 
 ### Additional Resources
 
-* [`pack create-builders` documentation](https://buildpacks.io/docs/using-pack/working-with-builders/)
+* [`pack builder create` documentation](https://buildpacks.io/docs/using-pack/working-with-builders/)
 
 ### What's next?
 

--- a/builders/alpine/README.md
+++ b/builders/alpine/README.md
@@ -5,7 +5,7 @@
 #### Creating the builder
 
 ```bash
-pack create-builder cnbs/sample-builder:alpine --config builder.toml
+pack builder create cnbs/sample-builder:alpine --config builder.toml
 ```
 
 #### Build app with builder

--- a/builders/bionic/README.md
+++ b/builders/bionic/README.md
@@ -8,7 +8,7 @@
 #### Creating the builder
 
 ```bash
-pack create-builder cnbs/sample-builder:bionic --config builder.toml
+pack builder create cnbs/sample-builder:bionic --config builder.toml
 ```
 
 #### Build app with builder

--- a/builders/dotnet-framework-1809/README.md
+++ b/builders/dotnet-framework-1809/README.md
@@ -8,7 +8,7 @@
 #### Creating the builder
 
 ```bash
-pack create-builder cnbs/sample-builder:dotnet-framework-1809 --config builder.toml
+pack builder create cnbs/sample-builder:dotnet-framework-1809 --config builder.toml
 ```
 
 #### Build app with builder

--- a/builders/nanoserver-1809/README.md
+++ b/builders/nanoserver-1809/README.md
@@ -8,7 +8,7 @@
 #### Creating the builder
 
 ```bash
-pack create-builder cnbs/sample-builder:nanoserver-1809 --config builder.toml 
+pack builder create cnbs/sample-builder:nanoserver-1809 --config builder.toml 
 ```
 
 #### Build app with builder

--- a/packages/hello-universe-windows/README.md
+++ b/packages/hello-universe-windows/README.md
@@ -5,5 +5,5 @@ A no-op buildpack whose intent is to show how meta-buildpacks can be packaged.
 ### Usage
 
 ```bash
-pack create-package cnbs/sample-package:hello-universe-windows --config package.toml
+pack buildpack package cnbs/sample-package:hello-universe-windows --config package.toml
 ```

--- a/packages/hello-universe/README.md
+++ b/packages/hello-universe/README.md
@@ -5,5 +5,5 @@ A no-op buildpack whose intent is to show how meta-buildpacks can be packaged.
 ### Usage
 
 ```bash
-pack create-package cnbs/sample-package:hello-universe --config package.toml
+pack buildpack package cnbs/sample-package:hello-universe --config package.toml
 ```


### PR DESCRIPTION
[Pack v0.16.0](https://github.com/buildpacks/pack/releases/tag/v0.16.0) deprecated a number of commands, including `create-builder` and `package-buildpack`. This change replaces references to the deprecated commands with their new equivalent, using the resource based subcommand model.

Additionally, this change utilizes the new pack config experimental command to set experimental, rather than echoing it into the file.

In the process, this also resolves #100, by replacing references to `create-package` (an old version of the `package-buildpack` command), with the new `pack buildpack package` command. 