### PR TITLE
Gitpodified the repository

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,4 @@
+FROM gitpod/workspace-full
+RUN sudo add-apt-repository ppa:cncf-buildpacks/pack-cli && \
+	sudo apt-get update && \
+	sudo apt-get install pack-cli

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,17 @@
+
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - init: |
+      chmod a+w /var/run/docker.sock && 
+      make build-linux
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: true
+vscode:
+  extensions:
+    - ms-azuretools.vscode-docker

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Buildpack Samples [![Build Status](https://github.com/buildpacks/samples/workflows/Build%20and%20Deploy/badge.svg?branch=main)](https://github.com/buildpacks/samples/actions)
+# Buildpack Samples 
+[![Build Status](https://github.com/buildpacks/samples/workflows/Build%20and%20Deploy/badge.svg?branch=main)](https://github.com/buildpacks/samples/actions) [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/buildpacks/samples)
 
 This repository contains sample implementations of the core components of the [Cloud Native Buildpacks](https://buildpacks.io/) (CNB) project for learning and testing purposes.
 
@@ -32,6 +33,12 @@ Follow the `README.md` docs at the root directory of each component to choose yo
 
 # Development
 
+## Development in the Browser
+Instead of setting everything up locally, you can open this repository in a completely pre-configured development environment in the cloud right from your browser:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/buildpacks/sample)
+
+## Local Development
 ### Prerequisites
 
 - [Docker](https://hub.docker.com/search/?type=edition&offering=community)


### PR DESCRIPTION
Hi buildpacks team,

here is a PR that fully-automates the dev setup of your sample repo with Gitpod, providing anyone with a pre-built, browser-based development environment in one click:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/*buildpacks/samples)

<img width="1659" alt="Screen Shot 2021-05-05 at 17 14 18" src="https://user-images.githubusercontent.com/377752/117165429-c6c69e00-adc5-11eb-822d-f280bc000d3a.png">

### What it does

* Pre-installs the buildpacks CLI tool via apt-get
* Runs `make build-linux` ahead-of-time so you don't need to wait
* Gives anyone immediate access to the pre-compiled buildpacks/samples project, and allows to easily edit & rebuild the code

I hope this can make life easier for contributors, and for maintainers who need to review many PRs (hint: you can already open this PR in Gitpod to easily review & test it without messing up your local checkout).

And I'm looking forward to your feedback on this PR! 🚀

Signed-off-by: Jan Koehnlein <jan@gitpod.io>