### PR TITLE
Adds wine stack & builder to demonstrate Windows without a WCOW daemon

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -36,7 +36,7 @@ jobs:
           curl -s -L -o pack.tgz ${{ steps.pack-download-url.outputs.result }}
           tar -xvf pack.tgz
       - name: Build
-        run: PACK_CMD=./pack make build-linux
+        run: PACK_CMD=./pack make build-linux build-wine
       - uses: azure/docker-login@v1
         if: (github.event_name == 'repository_dispatch') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         with:
@@ -44,9 +44,9 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - name: Deploy
         if: (github.event_name == 'repository_dispatch') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-        run: make deploy-linux
+        run: make deploy-linux deploy-wine
       - name: Clean up
-        run: make clean-linux
+        run: make clean-linux clean-wine
   build-windows:
     runs-on: windows-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ clean-linux:
 set-experimental:
 	@echo "> Setting experimental"
 	$(PACK_CMD) config experimental true
+
 ####################
 ## Wine
 ####################
@@ -305,7 +306,6 @@ clean-windows:
 
 	@echo "> Removing '.tmp'"
 	rm -rf .tmp
-
 
 ####################
 ## Windows pack for any daemon OS

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,61 @@ set-experimental:
 	@echo "> Setting experimental"
 	$(PACK_CMD) config experimental true
 ####################
+## Wine
+####################
+
+build-wine: build-stack-wine build-builder-wine build-buildpacks-wine
+
+build-stack-wine:
+	@echo "> Building 'wine' stack..."
+	bash stacks/build-stack.sh stacks/wine
+
+build-builder-wine: build-sample-root
+	@echo "> Building 'wine' builder..."
+	$(PACK_CMD) create-builder cnbs/sample-builder:wine --config $(SAMPLES_ROOT)/builders/wine/builder.toml $(PACK_FLAGS)
+
+build-wine-apps: build-sample-root
+	@echo "> Creating 'batch-script' app using 'wine' builder..."
+	$(PACK_CMD) build sample-batch-script-app:wine --builder cnbs/sample-builder:wine --path apps/batch-script $(PACK_FLAGS) $(PACK_BUILD_FLAGS)
+
+build-buildpacks-wine: build-sample-root
+	@echo "> Creating 'hello-moon-windows' app using 'wine' builder..."
+	$(PACK_CMD) build sample-hello-moon-windows-app:wine --builder cnbs/sample-builder:wine --buildpack $(SAMPLES_ROOT)/buildpacks/hello-world-windows --buildpack $(SAMPLES_ROOT)/buildpacks/hello-moon-windows $(PACK_FLAGS) $(PACK_BUILD_FLAGS)
+
+	@echo "> Creating 'hello-world-windows' app using 'wine' builder..."
+	$(PACK_CMD) build sample-hello-world-windows-app:wine --builder cnbs/sample-builder:wine --buildpack $(SAMPLES_ROOT)/buildpacks/hello-world-windows $(PACK_FLAGS) $(PACK_BUILD_FLAGS)
+
+deploy-wine: deploy-wine-stacks deploy-wine-builders
+
+deploy-wine-stacks:
+	@echo "> Deploying 'wine' stack..."
+	docker push cnbs/sample-stack-base:wine
+	docker push cnbs/sample-stack-run:wine
+	docker push cnbs/sample-stack-build:wine
+
+deploy-wine-builders:
+	@echo "> Deploying 'wine' builder..."
+	docker push cnbs/sample-builder:wine
+
+clean-wine:
+	@echo "> Removing 'wine' stack..."
+	docker rmi cnbs/sample-stack-base:wine || true
+	docker rmi cnbs/sample-stack-run:wine || true
+	docker rmi cnbs/sample-stack-build:wine || true
+
+	@echo "> Removing builders..."
+	docker rmi cnbs/sample-builder:wine || true
+
+	@echo "> Removing 'wine' apps..."
+	docker rmi sample-hello-moon-windows-app:wine || true
+	docker rmi sample-hello-world-windows-app:wine || true
+	docker rmi sample-batch-script-app:wine || true
+
+	@echo "> Removing '.tmp'"
+	rm -rf .tmp
+
+
+####################
 ## Windows
 ####################
 

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,6 @@ clean-wine:
 	@echo "> Removing '.tmp'"
 	rm -rf .tmp
 
-
 ####################
 ## Windows
 ####################

--- a/apps/batch-script/batch-script-buildpack/bin/build.bat
+++ b/apps/batch-script/batch-script-buildpack/bin/build.bat
@@ -5,11 +5,9 @@ echo --- Batch script buildpack
 set layers_dir=%1
 
 :: 2. SET DEFAULT START COMMAND
-(
-echo [[processes]]
-echo type = "web"
-echo command = "app.bat"
-) >> %layers_dir%\launch.toml
+echo [[processes]]       >> %layers_dir%\launch.toml
+echo type = "web"        >> %layers_dir%\launch.toml
+echo command = "app.bat" >> %layers_dir%\launch.toml
 
 :: LIST CONTENTS
 echo --- Hello Batch Script buildpack

--- a/apps/batch-script/batch-script-buildpack/buildpack.toml
+++ b/apps/batch-script/batch-script-buildpack/buildpack.toml
@@ -10,3 +10,7 @@ name = "Batch Script Buildpack"
 # Stacks that the buildpack will work with
 [[stacks]]
 id = "io.buildpacks.samples.stacks.nanoserver-1809"
+[[stacks]]
+id = "io.buildpacks.samples.stacks.wine"
+[[stacks]]
+id = "io.buildpacks.stacks.windows.servercore"

--- a/apps/batch-script/batch-script-buildpack/buildpack.toml
+++ b/apps/batch-script/batch-script-buildpack/buildpack.toml
@@ -10,7 +10,6 @@ name = "Batch Script Buildpack"
 # Stacks that the buildpack will work with
 [[stacks]]
 id = "io.buildpacks.samples.stacks.nanoserver-1809"
+
 [[stacks]]
 id = "io.buildpacks.samples.stacks.wine"
-[[stacks]]
-id = "io.buildpacks.stacks.windows.servercore"

--- a/builders/wine/README.md
+++ b/builders/wine/README.md
@@ -6,7 +6,7 @@ Supported `pack build` cases:
 * Test basic Windows buildpacks.
 * Build and inspect minimal Windows app images.
 * Test Windows lifecycle implementations ([example](#Test-Windows-lifecycle-implementations)).
-* Build or rebase an app image with a runnable Windows run image ([example](#Build-with-a-valid-Windows-run-image)).
+* Build or rebase an app image with a runnable Windows run image ([example](#Build-and-publish-a-runnable-Windows-app-image-to-a-registry)).
 
 What is **not** supported:
 * Creating runnable app images on a local daemon, due to Windows/Linux image formatting differences.
@@ -66,15 +66,13 @@ docker run --rm ${myrepo}/sample-app:wine
 ```
 
 ### How it works
-* Linux container runs [`lifecycle-wrapper.sh`](../../stacks/lifecycle-wrapper.sh) instead of normal Linux `lifecycle` binary.
+* Builder is a Linux image but with a Windows lifecycle. 
+* Linux build-phase container runs [`lifecycle-wrapper.sh`](../../stacks/wine/build/bin/lifecycle-wrapper.sh) instead of normal Linux `lifecycle` binary.
 * Lifecycle wrapper does the following:
   * Maps Linux container CNB dirs into Wine environment.
   * Sets up Wine dependencies.
   * Proxies `/var/run/docker.sock` to `127.0.0.1:2375` and sets `DOCKER_HOST`.
   * Execs `wine lifecycle.exe`, using phase name and arguments.
-* `lifecycle.exe` does the following:
-  * Runs normally as if in a Windows runtime environment.
+* `lifecycle.exe` runs normally as if in a Windows runtime environment:
   * Executes Windows-formatted buildpack executables (`.bat`,`.exe`), profile scripts, etc.
   * Exports app images in Windows format to either a registry or local daemon (with `scratch`-based run-image, unless otherwise specified).
-
-

--- a/builders/wine/README.md
+++ b/builders/wine/README.md
@@ -1,0 +1,80 @@
+# Sample Wine Builder
+
+A Linux builder that runs a Windows lifecycle using the [Wine emulation layer](https://www.winehq.org/) within a Linux container. Provides an emulated Windows environment for detect/build phases but generates _**unrunnable**_ app images by default.
+
+Supported `pack build` cases:
+* Test basic Windows buildpacks.
+* Build and inspect minimal Windows app images.
+* Test Windows lifecycle implementations ([example](#Test-Windows-lifecycle-implementations)).
+* Build or rebase an app image with a runnable Windows run image ([example](#Build-with-a-valid-Windows-run-image)).
+
+What is **not** supported:
+* Creating runnable app images on a local daemon, due to Windows/Linux image formatting differences.
+* Using buildpackages, due to Windows/Linux layer formatting differences.
+
+### Prerequisites
+* [Pack](https://buildpacks.io/docs/install-pack/)
+* Docker daemon with Linux container support
+
+### Usage
+
+#### Creating the builder
+
+```bash
+pack create-builder cnbs/sample-builder:wine --config builder.toml
+```
+
+#### Build app with builder
+
+```bash
+pack build sample-app --builder cnbs/sample-builder:wine --path ../../apps/batch-script/
+```
+
+_Note: After building, app is not runnable but can be inspected with `docker` or `dive`._
+
+#### Test Windows lifecycle implementations
+  ```bash
+  # Replace with locally built lifecycle tarball
+  sed -i.bak '$s!uri = .*!uri = "../../../lifecycle/out/lifecycle-v0.0.0+windows.x86-64.tgz"!' builder.toml
+
+  pack create-builder cnbs/sample-builder:wine --config builder.toml
+
+  pack build sample-app --builder cnbs/sample-builder:wine --trust-builder
+  ```
+
+#### Build and publish a runnable Windows app image to a registry
+
+```bash
+myrepo=<your repo name ex: "docker.io/cnbs">
+
+crane copy mcr.microsoft.com/windows/nanoserver:1809-amd64 ${myrepo}/sample-stack-run:nanoserver-1809-wine
+
+crane mutate ${myrepo}/sample-stack-run:nanoserver-1809-wine --label io.buildpacks.stack.id=io.buildpacks.samples.stacks.wine
+
+pack build ${myrepo}/sample-app:wine \
+  --publish \
+  --run-image ${myrepo}/sample-stack-run:nanoserver-1809-wine \
+  --builder cnbs/sample-builder:wine \
+  --path ../../apps/batch-script/ \
+  --trust-builder
+```
+
+After, with a WCOW daemon
+```bash
+docker run --rm ${myrepo}/sample-app:wine  
+## output: Buildpacks.io ASCII banner
+```
+
+### How it works
+* Linux container runs [`lifecycle-wrapper.sh`](../../stacks/lifecycle-wrapper.sh) instead of normal Linux `lifecycle` binary.
+* Lifecycle wrapper does the following:
+  * Maps Linux container CNB dirs into Wine environment.
+  * Sets up Wine dependencies.
+  * Proxies `/var/run/docker.sock` to `127.0.0.1:2375` and sets `DOCKER_HOST`.
+  * Execs `wine lifecycle.exe`, using phase name and arguments.
+* `lifecycle.exe` does the following:
+  * Runs normally as if in a Windows runtime environment.
+  * Executes Windows-formatted buildpack executables (`.bat`,`.exe`), profile scripts, etc.
+  * Exports app images in Windows format to either a registry or local daemon (with `scratch`-based run-image, unless otherwise specified).
+
+

--- a/builders/wine/builder.toml
+++ b/builders/wine/builder.toml
@@ -1,0 +1,19 @@
+# Buildpacks to include in builder
+[[buildpacks]]
+uri = "../../buildpacks/hello-world-windows"
+
+# Order used for detection
+[[order]]
+[[order.group]]
+id = "samples/hello-world-windows"
+version = "0.0.1"
+
+# Stack that will be used by the builder
+[stack]
+id = "io.buildpacks.samples.stacks.wine"
+run-image = "cnbs/sample-stack-run:wine"
+build-image = "cnbs/sample-stack-build:wine"
+
+# Requires explicit Windows lifecycle to override pack's Linux default
+[lifecycle]
+uri = "https://github.com/buildpacks/lifecycle/releases/download/v0.10.2/lifecycle-v0.10.2+windows.x86-64.tgz"

--- a/buildpacks/hello-moon-windows/buildpack.toml
+++ b/buildpacks/hello-moon-windows/buildpack.toml
@@ -14,3 +14,6 @@ id = "io.buildpacks.samples.stacks.nanoserver-1809"
 
 [[stacks]]
 id = "io.buildpacks.samples.stacks.dotnet-framework-1809"
+
+[[stacks]]
+id = "io.buildpacks.samples.stacks.wine"

--- a/buildpacks/hello-world-windows/buildpack.toml
+++ b/buildpacks/hello-world-windows/buildpack.toml
@@ -10,3 +10,6 @@ homepage = "https://github.com/buildpacks/samples/tree/main/buildpacks/hello-wor
 
 [[stacks]]
 id = "io.buildpacks.samples.stacks.nanoserver-1809"
+
+[[stacks]]
+id = "io.buildpacks.samples.stacks.wine"

--- a/stacks/wine/build/Dockerfile
+++ b/stacks/wine/build/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:groovy
+
+# Install packages that we want to make available at build time
+# Base + Wine 32/64bit + dependencies
+RUN dpkg --add-architecture i386 && \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  xz-utils ca-certificates \
+  git wget wine64 wine32 xvfb x11-apps socat && \
+  rm -rf /var/lib/apt/lists/*
+
+# Create symlinks for lifecycle executables to wrapper. The wrapper creates the Wine environment and calls lifecycle.exe
+COPY ./bin/lifecycle-wrapper.sh /cnb/lifecycle/analyzer
+COPY ./bin/lifecycle-wrapper.sh /cnb/lifecycle/builder
+COPY ./bin/lifecycle-wrapper.sh /cnb/lifecycle/creator
+COPY ./bin/lifecycle-wrapper.sh /cnb/lifecycle/detector
+COPY ./bin/lifecycle-wrapper.sh /cnb/lifecycle/exporter
+COPY ./bin/lifecycle-wrapper.sh /cnb/lifecycle/rebaser
+COPY ./bin/lifecycle-wrapper.sh /cnb/lifecycle/restorer
+RUN chmod 500 /cnb/lifecycle/*
+
+ARG cnb_uid=1000
+ARG cnb_gid=1000
+
+# Create user and group
+RUN groupadd cnb --gid ${cnb_gid} && \
+    useradd --uid ${cnb_uid} --gid ${cnb_gid} -m -s /bin/bash cnb
+
+# Set required CNB information
+ENV CNB_USER_ID=${cnb_uid}
+ENV CNB_GROUP_ID=${cnb_gid}
+
+# Set required CNB information
+ARG stack_id
+ENV CNB_STACK_ID=${stack_id}
+LABEL io.buildpacks.stack.id=${stack_id}
+
+# Set user and group (as declared in base image)
+USER ${CNB_USER_ID}:${CNB_GROUP_ID}

--- a/stacks/wine/build/Dockerfile
+++ b/stacks/wine/build/Dockerfile
@@ -17,7 +17,7 @@ COPY ./bin/lifecycle-wrapper.sh /cnb/lifecycle/detector
 COPY ./bin/lifecycle-wrapper.sh /cnb/lifecycle/exporter
 COPY ./bin/lifecycle-wrapper.sh /cnb/lifecycle/rebaser
 COPY ./bin/lifecycle-wrapper.sh /cnb/lifecycle/restorer
-RUN chmod 500 /cnb/lifecycle/*
+RUN chmod 555 /cnb/lifecycle/*
 
 ARG cnb_uid=1000
 ARG cnb_gid=1000

--- a/stacks/wine/build/bin/lifecycle-wrapper.sh
+++ b/stacks/wine/build/bin/lifecycle-wrapper.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -o errexit -o pipefail -o nounset
+
+# symlink CNB directories into C:
+mkdir -p         $HOME/.wine/drive_c/
+ln -s /cnb       $HOME/.wine/drive_c/
+ln -s /layers    $HOME/.wine/drive_c/
+ln -s /platform  $HOME/.wine/drive_c/
+ln -s /cache     $HOME/.wine/drive_c/
+ln -s /workspace $HOME/.wine/drive_c/
+
+# remove debug messages
+export WINEDEBUG=fixme-all,-ole,+msgbox    # suppress non-fatal messages: "fixme:", "err:ole"; log all "invisible" msgbox messages & Structured Error Handling failures
+export WINEDLLOVERRIDES="mscoree,mshtml="  # suppress wine-gecko messages
+
+# start background Xvfb for wine X11 dependency
+export DISPLAY=:0.0
+nohup Xvfb :0 -screen 0 1024x768x16 -nolisten unix &
+
+# start background socat to proxy between /var/run/docker.sock and tcp://localhost:2375, and override default //./pipe/docker_engine
+socat TCP-LISTEN:2375,reuseaddr,fork,bind=127.0.0.1 UNIX-CLIENT:/var/run/docker.sock &
+export DOCKER_HOST=tcp://localhost:2375
+
+# run wine once before running lifecycle to isolate setup errors
+if ! wine cmd /c exit 0 > /tmp/wine-build-init.log 2>&1; then
+    echo "Wine stack wrapper failed to initialize:"
+    cat /tmp/wine-build-init.log
+    exit 1
+fi
+
+exec wine64 $0.exe $*

--- a/stacks/wine/run/Dockerfile
+++ b/stacks/wine/run/Dockerfile
@@ -1,0 +1,9 @@
+# Based on scratch since lifecycle will export Windows-formatted images that cannot run on Linux but can be inspected and rebased.
+FROM scratch
+
+# Set required CNB information
+ARG stack_id
+LABEL io.buildpacks.stack.id="${stack_id}"
+
+# Add any file to create a minimal top layer, required for pack
+COPY Dockerfile /top-layer-placeholder


### PR DESCRIPTION
This adds stacks and builders to let users, buildpack authors and lifecycle contributors have access to a Windows-like  environments during build/detect phases, using only a Linux daemon. It can also help more advanced contributors to understand the differences between Linux and Windows functionality. It may also help catch and debug Windows bugs in cnb components.

The main limitations are:
* Wine's emulation is very similar to native WCOW but not identical.
* Generated app images are Windows-formatted and realistically runnable on Linux daemon, so run image is based on `scratch` to limit confusion.
* Buildpackages cannot be used as they'd confusingly need to be Linux-formatted but would be added intact to the generated Windows-formatted image.

More background and usage described in [builders/wine/README.html](https://github.com/micahyoung/buildpacks-samples/blob/wine-stack/builders/wine/README.md).

I published a sample builder to my personal repo `micahyoung/sample-builder:wine` with can be used to build this branch's `apps/batch-script`:

```bash
pack build my-wine-app --path apps/batch-script/ --builder micahyoung/sample-builder:wine

## output
===> DETECTING
[detector] samples/batch-script 0.0.1
===> ANALYZING
===> RESTORING
===> BUILDING
[builder] --- Batch script buildpack
[builder] --- Hello Batch Script buildpack
[builder] Echo is OFF
[builder] Here are the contents of the current working directory:
[builder] Volume in drive Z has no label.
[builder] Volume Serial Number is 0000-0000
[builder] 
[builder] Directory of Z:\workspace
[builder] 
[builder]   1/1/1970  12:00 AM  <DIR>         821D73A2F186\cnb       .
[builder]   6/9/2021   2:41 PM  <DIR>         NT AUTHORITY\ANONYMOUS L6/9/2021..
[builder]  2/16/2021  12:45 PM           863  821D73A2F186\cnb       app.bat
[builder]  9/18/2020   9:44 AM           207  821D73A2F186\cnb       project.toml
[builder]        2 files                    1,070 bytes
[builder] 
[builder]      Total files listed:
[builder]        2 files                    1,070 bytes
[builder]        2 directories     33,366,945,792 bytes free
[builder] 
===> EXPORTING
[exporter] Reusing 1/1 app layer(s)
[exporter] Reusing layer 'launcher'
[exporter] Reusing layer 'config'
[exporter] Reusing layer 'process-types'
[exporter] Adding label 'io.buildpacks.lifecycle.metadata'
[exporter] Adding label 'io.buildpacks.build.metadata'
[exporter] Adding label 'io.buildpacks.project.metadata'
[exporter] Setting default process type 'web'
[exporter] *** Images (ed52103e233f):
[exporter]       my-wine-app
Successfully built image my-wine-app
```

## From commit
- See builders/wine/README.html for more purpose
- Fixes incompatible syntax in Windows buildpacks

Signed-off-by: Micah Young <ymicah@vmware.com>