### PR TITLE
CI: Fix: Various CI issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  pack: buildpacks/pack@dev:1f2a08e
+  pack: buildpacks/pack@0.2
 workflows:
   version: 2
   main:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -28,7 +28,7 @@ jobs:
                 repo: "pack"
             }).then(result => {
                 return result.data.assets
-                  .filter(a => a.name.includes("linux"))
+                  .filter(a => a.name.includes("-linux.tgz"))
                   .map(a => a.browser_download_url)[0];
             })
       - name: Install pack

--- a/stacks/README.md
+++ b/stacks/README.md
@@ -7,10 +7,11 @@ Sample of stacks.
 To build the stack use the `./build-stack` script:
 
 ```text
-./build-stack.sh [-p <prefix> -v <version>] <dir>
-  -p    prefix to use for images      (default: sample/stack)
-  -v    version to tag images with    (default: latest)
-  <dir>  directory of stack to build
+Usage:
+  ./stacks/build-stack.sh [-f <prefix>] [-p <platform>] <dir>
+    -f    prefix to use for images      (default: cnbs/sample-stack)
+    -p    prefix to use for images      (default: amd64)
+   <dir>  directory of stack to build
 ```
 
 Example:

--- a/stacks/build-stack.sh
+++ b/stacks/build-stack.sh
@@ -4,21 +4,27 @@ set -e
 ID_PREFIX="io.buildpacks.samples.stacks"
 
 DEFAULT_PREFIX=cnbs/sample-stack
+DEFAULT_PLATFORM=amd64
 
 REPO_PREFIX=${DEFAULT_PREFIX}
+PLATFORM=${DEFAULT_PLATFORM}
 
 usage() {
   echo "Usage: "
-  echo "  $0 [-p <prefix>] <dir>"
-  echo "    -p    prefix to use for images      (default: ${DEFAULT_PREFIX})"
+  echo "  $0 [-f <prefix>] [-p <platform>] <dir>"
+  echo "    -f    prefix to use for images      (default: ${DEFAULT_PREFIX})"
+  echo "    -p    prefix to use for images      (default: ${DEFAULT_PLATFORM})"
   echo "   <dir>  directory of stack to build"
   exit 1; 
 }
 
 while getopts "v:p:" o; do
   case "${o}" in
-    p)
+    f)
       REPO_PREFIX=${OPTARG}
+      ;;
+    p)
+      PLATFORM=${OPTARG}
       ;;
     \?)
       echo "Invalid option: -$OPTARG" 1>&2
@@ -55,14 +61,14 @@ RUN_IMAGE=${REPO_PREFIX}-run:${TAG}
 BUILD_IMAGE=${REPO_PREFIX}-build:${TAG}
 
 if [[ -d "${IMAGE_DIR}/base" ]]; then
-  docker build -t "${BASE_IMAGE}" "${IMAGE_DIR}/base"
+  docker build --platform=${PLATFORM} -t "${BASE_IMAGE}" "${IMAGE_DIR}/base"
 fi
 
 echo "BUILDING ${BUILD_IMAGE}..."
-docker build --build-arg "base_image=${BASE_IMAGE}" --build-arg "stack_id=${STACK_ID}" -t "${BUILD_IMAGE}"  "${IMAGE_DIR}/build"
+docker build --platform=${PLATFORM} --build-arg "base_image=${BASE_IMAGE}" --build-arg "stack_id=${STACK_ID}" -t "${BUILD_IMAGE}"  "${IMAGE_DIR}/build"
 
 echo "BUILDING ${RUN_IMAGE}..."
-docker build --build-arg "base_image=${BASE_IMAGE}" --build-arg "stack_id=${STACK_ID}" -t "${RUN_IMAGE}" "${IMAGE_DIR}/run"
+docker build --platform=${PLATFORM} --build-arg "base_image=${BASE_IMAGE}" --build-arg "stack_id=${STACK_ID}" -t "${RUN_IMAGE}" "${IMAGE_DIR}/run"
 
 echo
 echo "STACK BUILT!"

--- a/stacks/wine/build/Dockerfile
+++ b/stacks/wine/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:groovy
+FROM ubuntu:jammy
 
 # Install packages that we want to make available at build time
 # Base + Wine 32/64bit + dependencies


### PR DESCRIPTION
* Wrong pack binary selected
  * Now that pack produces linux-arm64, the CI pipeline is picking up the wrong variant. This fix adds additional string matching to select the proper variant.
* pack orb pinned to old dev version
  * Since [dev versions are only kept for 90 days](https://discuss.circleci.com/t/orb-dev-release/42792), ours had expired.
  * Orb version pinned to a _minor_ version of `0.2` to prevent having to update the version for patch releases.
* wine stack not building
  * We were using an EOL version of ubuntu (groovy) as the base image
  * Additionally, we set a default platform of amd64 to be able to install i386 dependencies on arm64-based systems.