### PR TITLE
CI: Fix: Windows build and deploy pipeline

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,7 +12,7 @@ on:
       - pack-release
 
 jobs:
-  build-linux:
+  build-deploy-linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
         run: make deploy-linux deploy-wine
       - name: Clean up
         run: make clean-linux clean-wine
-  build-windows:
+  build-deploy-windows:
     strategy:
       matrix:
         include:
@@ -90,5 +90,39 @@ jobs:
       - name: Deploy
         if: (github.event_name == 'repository_dispatch') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: make deploy-windows-${{ matrix.version }}
-      - name: Clean up
-        run: make clean-windows
+  build-deploy-windows-packages:
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v2
+      - name: Determine download URL for latest pack
+        id: pack-download-url
+        uses: actions/github-script@0.4.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
+          script: |
+            return github.repos.getLatestRelease({
+                owner: "buildpacks",
+                repo: "pack"
+            }).then(result => {
+                return result.data.assets
+                  .filter(a => a.name.includes("windows"))
+                  .map(a => a.browser_download_url)[0];
+            })
+      - name: Install pack
+        run: |
+          curl -s -L -o pack.zip ${{ steps.pack-download-url.outputs.result }}
+          tar -xvf pack.zip
+          mkdir ~\.pack
+      - name: Set Experimental
+        run: make set-experimental
+      - name: Build
+        run: make build-windows-packages
+      - uses: azure/docker-login@v1
+        if: (github.event_name == 'repository_dispatch') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        with:
+          username: cnbs
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Deploy
+        if: (github.event_name == 'repository_dispatch') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        run: make deploy-windows-packages

--- a/Makefile
+++ b/Makefile
@@ -273,9 +273,16 @@ build-windows-packages: build-sample-root
 	@echo "> Creating 'hello-universe-windows' buildpack package"
 	$(PACK_CMD) buildpack package cnbs/sample-package:hello-universe-windows --config $(SAMPLES_ROOT)/packages/hello-universe-windows/package.toml $(PACK_FLAGS)
 
-deploy-windows-1809: deploy-windows-stacks-1809 deploy-windows-builders-1809 deploy-windows-packages
+deploy-windows-packages:
+	@echo "> Deploying windows packages..."
+	docker push cnbs/sample-package:hello-world-windows
+	docker push cnbs/sample-package:hello-universe-windows
 
-deploy-windows-2004: deploy-windows-stacks-2004 deploy-windows-builders-2004 deploy-windows-packages
+deploy-windows-1809: deploy-windows-stacks-1809 deploy-windows-builders-1809
+
+deploy-windows-2004: deploy-windows-stacks-2004 deploy-windows-builders-2004
+
+deploy-windows-2022: deploy-windows-stacks-2022 deploy-windows-builders-2022
 
 deploy-windows-stacks-1809: deploy-windows-stacks-nanoserver-1809 deploy-windows-stacks-dotnet-framework-1809
 
@@ -303,11 +310,6 @@ deploy-windows-stacks-dotnet-framework-2022:
 	@echo "> Deploying 'dotnet-framework-2022' stack..."
 	docker push cnbs/sample-stack-run:dotnet-framework-2022
 	docker push cnbs/sample-stack-build:dotnet-framework-2022
-
-deploy-windows-packages:
-	@echo "> Deploying windows packages..."
-	docker push cnbs/sample-package:hello-world-windows
-	docker push cnbs/sample-package:hello-universe-windows
 
 deploy-windows-builders-1809: deploy-windows-builders-nanoserver-1809 deploy-windows-builders-dotnet-framework-1809
 


### PR DESCRIPTION
We were missing a make target of deploy-windows-2022.

Additionally, this commit separates building and deploying Windows packages
to its own job.