### PR TITLE
Add libyaml to allow ruby version bump

### DIFF
--- a/stacks/bionic/base/Dockerfile
+++ b/stacks/bionic/base/Dockerfile
@@ -5,7 +5,7 @@ ARG cnb_gid=1000
 
 # Install packages that we want to make available at both build and run time
 RUN apt-get update && \
-  apt-get install -y xz-utils ca-certificates && \
+  apt-get install -y xz-utils ca-certificates libyaml-0-2 && \
   rm -rf /var/lib/apt/lists/*
 
 # Create user and group


### PR DESCRIPTION
The ruby distribution now ships with bundle by default.  However, it requires that libyaml is available.  We supply libyaml in our base sample image in order to simplify our documentation.

Signed-off-by: Aidan Delaney <adelaney21@bloomberg.net>