### PR TITLE
Test that extensions are present in alpine builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ build-linux-builders: build-builder-alpine build-builder-bionic
 build-builder-alpine: build-linux-packages build-sample-root
 	@echo "> Building 'alpine' builder..."
 	$(PACK_CMD) builder create cnbs/sample-builder:alpine --config $(SAMPLES_ROOT)/builders/alpine/builder.toml $(PULL_POLICY_NEVER)
+	docker run cnbs/sample-builder:alpine ls /cnb/extensions/samples_curl
 
 build-builder-bionic: build-linux-packages build-sample-root
 	@echo "> Building 'bionic' builder..."


### PR DESCRIPTION
In the image published to Docker Hub, /cnb/extensions is empty