### PR TITLE
Allow sample buildpacks on all stacks

### DIFF
--- a/buildpacks/hello-moon/buildpack.toml
+++ b/buildpacks/hello-moon/buildpack.toml
@@ -17,3 +17,6 @@ id = "io.buildpacks.samples.stacks.alpine"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
+
+[[stacks]]
+id = "*"

--- a/buildpacks/hello-processes/buildpack.toml
+++ b/buildpacks/hello-processes/buildpack.toml
@@ -17,3 +17,6 @@ id = "io.buildpacks.samples.stacks.alpine"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
+
+[[stacks]]
+id = "*"

--- a/buildpacks/hello-world/buildpack.toml
+++ b/buildpacks/hello-world/buildpack.toml
@@ -17,3 +17,6 @@ id = "io.buildpacks.samples.stacks.alpine"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
+
+[[stacks]]
+id = "*"

--- a/buildpacks/java-maven/buildpack.toml
+++ b/buildpacks/java-maven/buildpack.toml
@@ -17,5 +17,8 @@ id = "io.buildpacks.samples.stacks.bionic"
 id = "io.buildpacks.samples.stacks.alpine"
 
 [[stacks]]
+id = "*"
+
+[[stacks]]
 id = "io.buildpacks.stacks.bionic"
 mixins = ["build:set=shell-utils"]

--- a/buildpacks/kotlin-gradle/buildpack.toml
+++ b/buildpacks/kotlin-gradle/buildpack.toml
@@ -16,5 +16,8 @@ id = "io.buildpacks.samples.stacks.bionic"
 id = "io.buildpacks.samples.stacks.alpine"
 
 [[stacks]]
+id = "*"
+
+[[stacks]]
 id = "io.buildpacks.stacks.bionic"
 mixins = ["build:set=shell-utils"]

--- a/buildpacks/ruby-bundler/buildpack.toml
+++ b/buildpacks/ruby-bundler/buildpack.toml
@@ -13,5 +13,8 @@ homepage = "https://github.com/buildpacks/samples/tree/main/buildpacks/ruby-bund
 id = "io.buildpacks.samples.stacks.bionic"
 
 [[stacks]]
+id = "*"
+
+[[stacks]]
 id = "io.buildpacks.stacks.bionic"
 mixins = ["build:set=shell-utils"]


### PR DESCRIPTION
Expand the stacks that we support for sample buildpacks

Fixes #139 