### PR TITLE
Update pack version for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ workflows:
           working-directory: apps/java-maven
           image-name: cnbs/circleci-sample
           builder: 'cnbs/sample-builder:jammy'
+          version: '0.29.0'
       - test:
           requires:
             - pack/build


### PR DESCRIPTION
The default pack version on CircleCI is 0.18.  Use the
latest version.