### PR TITLE
Fix the command parameter to work with Buildpacks API 0.9

### DIFF
--- a/apps/bash-script/bash-script-buildpack/bin/build
+++ b/apps/bash-script/bash-script-buildpack/bin/build
@@ -10,7 +10,7 @@ layers_dir=$1
 cat >> "${layers_dir}/launch.toml" <<EOL
 [[processes]]
 type = "web"
-command = "./app.sh"
+command = ["./app.sh"]
 EOL
 
 # LIST CONTENTS

--- a/apps/batch-script/batch-script-buildpack/bin/build.bat
+++ b/apps/batch-script/batch-script-buildpack/bin/build.bat
@@ -7,7 +7,7 @@ set layers_dir=%1
 :: 2. SET DEFAULT START COMMAND
 echo [[processes]]       >> %layers_dir%\launch.toml
 echo type = "web"        >> %layers_dir%\launch.toml
-echo command = "app.bat" >> %layers_dir%\launch.toml
+echo command = ["app.bat"] >> %layers_dir%\launch.toml
 
 :: LIST CONTENTS
 echo --- Hello Batch Script buildpack


### PR DESCRIPTION
In the example we are using Buildpacks API 0.9
https://github.com/buildpacks/samples/blob/main/apps/bash-script/bash-script-buildpack/buildpack.toml#L2 which requires to have a `command = [something]` as specified in the spec: https://github.com/buildpacks/spec/blob/buildpack/v0.9/buildpack.md#launchtoml-toml
But in the builder we have a string instead of an array, causing an error when processed: https://github.com/buildpacks/samples/blob/main/apps/bash-script/bash-script-buildpack/bin/build#L13 

This PR just fix that putting the `./app.bat` or `./app.sh` command into an array