### PR TITLE
Removing unsupported entry

### DIFF
--- a/buildpacks/hello-moon/bin/detect
+++ b/buildpacks/hello-moon/bin/detect
@@ -13,7 +13,6 @@ cat >> "${plan_path}" <<EOL
 #
 [[requires]]
 name = "some-world"
-version = "0.1"     # Optional
 
 [requires.metadata]
 world = "Earth-616" # Optional


### PR DESCRIPTION
I'm working on a tutorial using the samples and running the detector providing some buildpacks I get an error on the `hello-moon` one about the `version` key in the `detector` file.
The platform_api version I'm using is: 
```sh
❯ echo $CNB_PLATFORM_API
0.12
```
this is the output: 
```
❯ $CNB_LIFECYCLE_PATH/detector -log-level debug -layers="./layers" -order="./order.toml" -buildpacks="./buildpacks" -app apps/bash-script
Starting detector...
Parsing inputs...
Ensuring privileges...
Executing command...
Timer: Detector started at 2023-08-29T12:23:26+02:00
======== Results ========
fail: samples/java-maven@0.0.1
======== Results ========
fail: samples/kotlin-gradle@0.0.1
======== Results ========
fail: samples/ruby-bundler@0.0.1
======== Error: samples/hello-moon@0.0.1 ========
buildpack samples/hello-moon has a "version" key which is not supported. "metadata.version" should be used instead
======== Results ========
pass: samples/hello-world@0.0.1
err:  samples/hello-moon@0.0.1
Timer: Detector ran for 152.19425ms and ended at 2023-08-29T12:23:26+02:00
ERROR: No buildpack groups passed detection.
ERROR: failed to detect: buildpack(s) failed with err
```
No new files have been generated.

Removing that line from the detector I get:
```
❯ $CNB_LIFECYCLE_PATH/detector -log-level debug -layers="./layers" -order="./order.toml" -buildpacks="./buildpacks" -app apps/bash-script
Starting detector...
Parsing inputs...
Ensuring privileges...
Executing command...
Timer: Detector started at 2023-08-29T12:27:19+02:00
======== Results ========
fail: samples/java-maven@0.0.1
======== Results ========
fail: samples/kotlin-gradle@0.0.1
======== Results ========
fail: samples/ruby-bundler@0.0.1
======== Results ========
pass: samples/hello-world@0.0.1
pass: samples/hello-moon@0.0.1
Resolving plan... (try #1)
samples/hello-world 0.0.1
samples/hello-moon  0.0.1
Timer: Detector ran for 974.819292ms and ended at 2023-08-29T12:27:20+02:00
```
and the plan.toml and group.toml files are there as expected.
