### PR TITLE
Build nanoserver along with dotnet framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ set-experimental:
 ## Windows
 ####################
 
-build-windows-2022: build-windows-packages build-dotnet-framework-2022
+build-windows-2022: build-windows-packages build-dotnet-framework-2022 build-nanoserver-2022
 
 build-nanoserver-2022: build-stack-nanoserver-2022 build-builder-nanoserver-2022 build-buildpacks-nanoserver-2022
 


### PR DESCRIPTION
So that it can be deployed later

This should fix the Windows pipeline that was broken with https://github.com/buildpacks/samples/pull/172, where we try to deploy a stack that wasn't built yet 