### PR TITLE
Correct redirects in JVM exec.d scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,12 @@ build-jammy: build-base-jammy build-builder-jammy build-buildpacks-jammy
 
 build-base-alpine:
 	@echo "> Building 'alpine' base images..."
+	${PACK_CMD} config experimental true
 	bash base-images/build.sh alpine
 
 build-base-jammy:
 	@echo "> Building 'jammy' base images..."
+	${PACK_CMD} config experimental true
 	bash base-images/build.sh jammy
 
 build-linux-builders: build-builder-alpine build-builder-jammy

--- a/base-images/jammy/base/Dockerfile
+++ b/base-images/jammy/base/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:jammy
 
+# Workaround for docker <= 20.10.9
+RUN sed -i -e 's/^APT/# APT/' -e 's/^DPkg/# DPkg/' /etc/apt/apt.conf.d/docker-clean
+
 # Install packages that we want to make available at both build and run time
 RUN apt update && \
   apt install -y xz-utils ca-certificates libyaml-0-2 && \

--- a/buildpacks/java-maven/bin/build
+++ b/buildpacks/java-maven/bin/build
@@ -61,13 +61,15 @@ EOF
 
   mkdir -p ${jdk_layer_dir}/exec.d
   cat > "${jdk_layer_dir}/exec.d/jdk.sh" << EOF
-echo JAVA_HOME=${jdk_layer_dir} > \$1
+echo JAVA_HOME=${jdk_layer_dir}
 if [[ -z \$LD_LIBRARY_PATH ]]; then
-  echo LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server" >> \$1
+  echo LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server"
 else
-  echo LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server:${LD_LIBRARY_PATH}" >> \$1
+  echo LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server:${LD_LIBRARY_PATH}"
 fi
+echo PATH="\${PATH}:\${JAVA_HOME}/bin"
 EOF
+  chmod u+x,g+x "${jdk_layer_dir}/exec.d/jdk.sh"
 fi
 export JAVA_HOME=${jdk_layer_dir}
 

--- a/buildpacks/kotlin-gradle/bin/build
+++ b/buildpacks/kotlin-gradle/bin/build
@@ -58,12 +58,13 @@ EOF
 
   mkdir -p ${jdk_layer_dir}/exec.d
   cat > "${jdk_layer_dir}/exec.d/jdk.sh" << EOF
-echo JAVA_HOME=${jdk_layer_dir} > \$1
+echo JAVA_HOME=${jdk_layer_dir}
 if [[ -z \$LD_LIBRARY_PATH ]]; then
-  echo LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server" >> \$1
+  echo LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server"
 else
-  echo LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server:${LD_LIBRARY_PATH}" >> \$1
+  echo LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server:${LD_LIBRARY_PATH}"
 fi
+echo PATH="\${PATH}:\${JAVA_HOME}/bin"
 EOF
 fi
 


### PR DESCRIPTION
The exec.d scripts in maven and kotlin examples were not outputting key="value" pairs to stdout.