### PR TITLE
Correct getopts flags

### DIFF
--- a/base-images/build.sh
+++ b/base-images/build.sh
@@ -18,7 +18,7 @@ usage() {
   exit 1; 
 }
 
-while getopts "v:p:" o; do
+while getopts ":f:p:" o; do
   case "${o}" in
     f)
       REPO_PREFIX=${OPTARG}


### PR DESCRIPTION
* The option `-v` does not exist, but `-f`.

* Prefix the option string with a leading colon so the 'actual' bad flag gets reported.

Before:
```shell
./build.sh: illegal option -- w
Invalid option: -
Usage:
  ./build.sh [-f <prefix>] [-p <platform>] <dir>
    -f    prefix to use for images      (default: cnbs/sample-base)
    -p    prefix to use for images      (default: linux/amd64)
   <dir>  directory to build
```
  Now:
```shell
Invalid option: -w
Usage:
  ./build.sh [-f <prefix>] [-p <platform>] <dir>
    -f    prefix to use for images      (default: cnbs/sample-base)
    -p    prefix to use for images      (default: linux/amd64)
   <dir>  directory to build
```

