### PR TITLE
base-images: Support podman

### DIFF
--- a/base-images/build.sh
+++ b/base-images/build.sh
@@ -62,14 +62,16 @@ RUN_IMAGE=${REPO_PREFIX}-run:${TAG}
 BUILD_IMAGE=${REPO_PREFIX}-build:${TAG}
 FROM_IMAGE=$(head -n1 "${IMAGE_DIR}"/base/Dockerfile | cut -d' ' -f2)
 
+CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
+
 # Get target distro information
-DISTRO_NAME=$(docker run --rm "${FROM_IMAGE}" cat /etc/os-release | grep '^ID=' | cut -d'=' -f2)
+DISTRO_NAME=$(${CONTAINER_RUNTIME} run --rm "${FROM_IMAGE}" cat /etc/os-release | grep '^ID=' | cut -d'=' -f2)
 echo "DISTRO_NAME: ${DISTRO_NAME}"
-DISTRO_VERSION=$(docker run --rm "${FROM_IMAGE}" cat /etc/os-release | grep '^VERSION_ID=' | cut -d'=' -f2)
+DISTRO_VERSION=$(${CONTAINER_RUNTIME} run --rm "${FROM_IMAGE}" cat /etc/os-release | grep '^VERSION_ID=' | cut -d'=' -f2)
 echo "DISTRO_VERSION: ${DISTRO_VERSION}"
 
 if [[ -d "${IMAGE_DIR}/base" ]]; then
-  docker build --platform=${PLATFORM} \
+  ${CONTAINER_RUNTIME} build --platform=${PLATFORM} \
   --build-arg "distro_name=${DISTRO_NAME}" \
   --build-arg "distro_version=${DISTRO_VERSION}" \
   --build-arg "stack_id=${STACK_ID}" \
@@ -78,14 +80,14 @@ if [[ -d "${IMAGE_DIR}/base" ]]; then
 fi
 
 echo "BUILDING ${BUILD_IMAGE}..."
-docker build --platform=${PLATFORM} \
+${CONTAINER_RUNTIME} build --platform=${PLATFORM} \
   --build-arg "base_image=${BASE_IMAGE}" \
   --build-arg "stack_id=${STACK_ID}" \
   -t "${BUILD_IMAGE}" \
   "${IMAGE_DIR}/build"
 
 echo "BUILDING ${RUN_IMAGE}..."
-docker build --platform=${PLATFORM} \
+${CONTAINER_RUNTIME} build --platform=${PLATFORM} \
   --build-arg "base_image=${BASE_IMAGE}" \
   -t "${RUN_IMAGE}" \
   "${IMAGE_DIR}/run"


### PR DESCRIPTION
I do not have `docker` running on my macos and FreeBSD system, but `podman`.

Sample run on my macos:

```shell
➜  base-images git:(support_podman) ✗ export CONTAINER_RUNTIME=podman
➜  base-images git:(support_podman) ✗ ./build.sh noble
Resolved "ubuntu" as an alias (/etc/containers/registries.conf.d/000-shortnames.conf)
Trying to pull docker.io/library/ubuntu:noble...

...


Successfully tagged localhost/cnbs/sample-base-run:noble
9845fd9b5b3a573e72d1a21b0e69a7cddcce668be55a7734b24185f9ba8e2425

BASE IMAGES BUILT!

Images:
    cnbs/sample-base:noble
    cnbs/sample-base-build:noble
    cnbs/sample-base-run:noble


➜  base-images git:(support_podman) ✗ podman images
REPOSITORY                        TAG         IMAGE ID      CREATED             SIZE
localhost/cnbs/sample-base-run    noble       9845fd9b5b3a  30 seconds ago      84.3 MB
localhost/cnbs/sample-base-build  noble       fb1bd63b452b  34 seconds ago      173 MB
localhost/cnbs/sample-base        noble       3f413700a6fc  About a minute ago  90.8 MB
<none>                            <none>      d90f11c075cd  2 weeks ago         103 MB
docker.io/library/ubuntu          noble       493218ed0f40  2 weeks ago         80.6 MB
docker.io/cnbs/sample-base        noble       ef15806a9951  2 months ago        84.3 MB
```    